### PR TITLE
refactor fetching data using getServerSideProps

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,23 +8,25 @@ import { Product } from "@/types/product";
 import { filterProducts } from "@/utils/filter-products";
 import ErrorPage from "next/error";
 import { useState } from "react";
+import { requestProducts } from "@/utils/request-products";
 
-const Home = (): JSX.Element => {
+const Home = ({ data: products }: { data: Product[] }): JSX.Element => {
   const [productSearchQuery, setProductSearchQuery] = useState<string>("");
 
-  const { data: products, isLoading, error } = useProducts();
+  // const { data: products, isLoading, error } = useProducts();
 
   const filteredProducts = filterProducts(products, productSearchQuery);
 
-  if (error) {
-    return (
-      <ErrorPage
-        title="There was an error retrieving the products. Please refresh the page and try again"
-        statusCode={404}
-        withDarkMode={false}
-      />
-    );
-  }
+  // if (error) {
+  //   return (
+  //     <ErrorPage
+  //       title="There was an error retrieving the products. Please refresh the page and try again"
+  //       statusCode={404}
+  //       withDarkMode={false}
+  //     />
+  //   );
+  // }
+
   return (
     <>
       <SearchProducts
@@ -32,19 +34,32 @@ const Home = (): JSX.Element => {
         setProductSearchQuery={setProductSearchQuery}
       />
       <ProductCardsContainer>
-        {isLoading ? (
-          Array.from({ length: 10 }).map((_, index) => (
-            <LoadingProductCard key={index} />
-          ))
-        ) : filteredProducts.length ? (
-          filteredProducts.map((product: Product) => (
-            <ProductCard key={product.id} {...product} />
-          ))
-        ) : (
-          <NoProductMessage message="No product found!" />
-        )}
+        {
+          //  isLoading ? (
+          //    Array.from({ length: 10 }).map((_, index) => (
+          //      <LoadingProductCard key={index} />
+          //    ))
+          //  ) :
+          filteredProducts.length ? (
+            filteredProducts.map((product: Product) => (
+              <ProductCard key={product.id} {...product} />
+            ))
+          ) : (
+            <NoProductMessage message="No product found!" />
+          )
+        }
       </ProductCardsContainer>
     </>
   );
 };
 export default Home;
+
+export async function getServerSideProps() {
+  const data = await requestProducts();
+
+  return {
+    props: {
+      data,
+    },
+  };
+}


### PR DESCRIPTION
To make it simple I removed the `TanStackQuery` and used my factory function `requestProducts` in the `getServerSideProps` and received the data through the `Home` page props.

The reason that I didn't use `getStaticProps` was that I assumed an online eCommerce shop is adding data very often therefore when our data changes frequently, we need to use `getServerSideProps` which generates the props on each request at the runtime.

On the other hand, if we had a use case that unlikely to change, therefore can be pre-generated using `getStaticProps`.

I also have this specific issue before in my project which I had to refactor from `getStaticProps` to `getServerSideProps`. [link to the commit](https://github.com/herol3oy/femalerockers/commit/99dfdb5c6b23212dcc6a07edc5f285cf2d0ac895#diff-bb47e9ef86a5dbd85a42ca6bb2d55ffc8db431b41019714abb24331c61ed7036R201)





